### PR TITLE
refactor: extract cloud-init template to embed.FS (#14)

### DIFF
--- a/internal/cloudinit/templates/userdata.yaml.tmpl
+++ b/internal/cloudinit/templates/userdata.yaml.tmpl
@@ -1,0 +1,87 @@
+#cloud-config
+# Minimal cloud-init for coop agent containers
+# Base image (coop-agent-base) has all tools pre-installed
+
+hostname: {{.Hostname}}
+manage_etc_hosts: true
+locale: en_US.UTF-8
+timezone: UTC
+
+users:
+  - name: agent
+    uid: 1000
+    groups: [sudo, adm]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+{{- if .SSHPubKey }}
+    ssh_authorized_keys:
+      - {{.SSHPubKey}}
+{{- end }}
+
+# Skip package updates - base image has everything
+package_update: false
+package_upgrade: false
+
+write_files:
+  - path: /etc/ssh/sshd_config.d/99-agent-hardening.conf
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      PubkeyAuthentication yes
+      X11Forwarding no
+      AllowAgentForwarding yes
+      AllowTcpForwarding yes
+      PrintMotd no
+    permissions: '0644'
+
+  - path: /home/agent/.bashrc.d/agent-env.sh
+    content: |
+      export GOROOT=/usr/local/go
+      export GOPATH=$HOME/go
+      export PATH=$HOME/.local/bin:$PATH:$GOROOT/bin:$GOPATH/bin
+      export EDITOR=vim
+    permissions: '0644'
+
+  - path: /home/agent/.gitconfig
+    content: |
+      [user]
+          name = Agent
+          email = agent@sandbox.local
+      [init]
+          defaultBranch = main
+      [safe]
+          directory = *
+    permissions: '0644'
+
+runcmd:
+  # Ensure agent user exists with correct shell (handles UID conflicts)
+  - id agent >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 -U agent
+  - usermod -s /bin/bash agent
+  - usermod -aG sudo,adm agent || true
+  - 'echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent'
+  
+  # Setup agent home directories
+  - mkdir -p /home/agent/.bashrc.d /home/agent/.local/bin /home/agent/.config
+  - mkdir -p /home/agent/.ssh /home/agent/.vscode-server /home/agent/workspace /home/agent/go/bin
+  - chmod 700 /home/agent/.ssh
+{{- if .SSHPubKey }}
+  - 'echo "{{.SSHPubKey}}" > /home/agent/.ssh/authorized_keys'
+  - chmod 600 /home/agent/.ssh/authorized_keys
+{{- end }}
+  - 'grep -q "bashrc.d" /home/agent/.bashrc || echo "for f in ~/.bashrc.d/*.sh; do [ -r \"$f\" ] && . \"$f\"; done" >> /home/agent/.bashrc'
+  
+  # Optional upgrades (non-fatal) - user version in ~/.local/bin takes precedence
+  - su - agent -c 'claude upgrade' || true
+  
+  # Firewall setup
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp
+  - ufw allow from 10.0.0.0/8 to any port {{.AgentPort}}
+  - ufw --force enable
+  
+  # Finalize
+  - systemctl restart sshd
+  - chown -R agent:agent /home/agent
+
+final_message: "Cloud-init completed in $UPTIME seconds"

--- a/internal/cloudinit/userdata.go
+++ b/internal/cloudinit/userdata.go
@@ -3,8 +3,12 @@ package cloudinit
 
 import (
 	"bytes"
+	"embed"
 	"text/template"
 )
+
+//go:embed templates/*.tmpl
+var templateFS embed.FS
 
 // Config holds the configuration for generating cloud-init user-data.
 type Config struct {
@@ -23,7 +27,12 @@ func DefaultConfig() Config {
 
 // Generate produces the cloud-init user-data YAML.
 func Generate(cfg Config) (string, error) {
-	tmpl, err := template.New("userdata").Parse(userdataTemplate)
+	tmplData, err := templateFS.ReadFile("templates/userdata.yaml.tmpl")
+	if err != nil {
+		return "", err
+	}
+
+	tmpl, err := template.New("userdata").Parse(string(tmplData))
 	if err != nil {
 		return "", err
 	}
@@ -35,92 +44,3 @@ func Generate(cfg Config) (string, error) {
 
 	return buf.String(), nil
 }
-
-const userdataTemplate = `#cloud-config
-# Minimal cloud-init for coop agent containers
-# Base image (coop-agent-base) has all tools pre-installed
-
-hostname: {{.Hostname}}
-manage_etc_hosts: true
-locale: en_US.UTF-8
-timezone: UTC
-
-users:
-  - name: agent
-    uid: 1000
-    groups: [sudo, adm]
-    shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
-{{- if .SSHPubKey }}
-    ssh_authorized_keys:
-      - {{.SSHPubKey}}
-{{- end }}
-
-# Skip package updates - base image has everything
-package_update: false
-package_upgrade: false
-
-write_files:
-  - path: /etc/ssh/sshd_config.d/99-agent-hardening.conf
-    content: |
-      PermitRootLogin no
-      PasswordAuthentication no
-      PubkeyAuthentication yes
-      X11Forwarding no
-      AllowAgentForwarding yes
-      AllowTcpForwarding yes
-      PrintMotd no
-    permissions: '0644'
-
-  - path: /home/agent/.bashrc.d/agent-env.sh
-    content: |
-      export GOROOT=/usr/local/go
-      export GOPATH=$HOME/go
-      export PATH=$HOME/.local/bin:$PATH:$GOROOT/bin:$GOPATH/bin
-      export EDITOR=vim
-    permissions: '0644'
-
-  - path: /home/agent/.gitconfig
-    content: |
-      [user]
-          name = Agent
-          email = agent@sandbox.local
-      [init]
-          defaultBranch = main
-      [safe]
-          directory = *
-    permissions: '0644'
-
-runcmd:
-  # Ensure agent user exists with correct shell (handles UID conflicts)
-  - id agent >/dev/null 2>&1 || useradd -m -s /bin/bash -u 1000 -U agent
-  - usermod -s /bin/bash agent
-  - usermod -aG sudo,adm agent || true
-  - 'echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent'
-  
-  # Setup agent home directories
-  - mkdir -p /home/agent/.bashrc.d /home/agent/.local/bin /home/agent/.config
-  - mkdir -p /home/agent/.ssh /home/agent/.vscode-server /home/agent/workspace /home/agent/go/bin
-  - chmod 700 /home/agent/.ssh
-{{- if .SSHPubKey }}
-  - 'echo "{{.SSHPubKey}}" > /home/agent/.ssh/authorized_keys'
-  - chmod 600 /home/agent/.ssh/authorized_keys
-{{- end }}
-  - 'grep -q "bashrc.d" /home/agent/.bashrc || echo "for f in ~/.bashrc.d/*.sh; do [ -r \"$f\" ] && . \"$f\"; done" >> /home/agent/.bashrc'
-  
-  # Optional upgrades (non-fatal) - user version in ~/.local/bin takes precedence
-  - su - agent -c 'claude upgrade' || true
-  
-  # Firewall setup
-  - ufw default deny incoming
-  - ufw default allow outgoing
-  - ufw allow 22/tcp
-  - ufw allow from 10.0.0.0/8 to any port {{.AgentPort}}
-  - ufw --force enable
-  
-  # Finalize
-  - systemctl restart sshd
-  - chown -R agent:agent /home/agent
-
-final_message: "Cloud-init completed in $UPTIME seconds"
-`


### PR DESCRIPTION
## Summary

Extract the inline cloud-init template string to an embedded YAML file for better maintainability.

## Changes

- **New file**: [internal/cloudinit/templates/userdata.yaml.tmpl](internal/cloudinit/templates/userdata.yaml.tmpl) — the cloud-init template as a proper YAML file with syntax highlighting support
- **Updated**: [internal/cloudinit/userdata.go](internal/cloudinit/userdata.go) — use `embed.FS` to load template at compile time

## Benefits

- Template is now syntax-highlighted in editors (YAML mode)
- Easier to review and maintain separate from Go code
- No runtime file I/O — template is embedded in binary
- Template content unchanged; all existing tests pass

## Issues Closed

Closes #14 (Cloud-init template embedded as string)

## Testing

- `go build ./...` ✅
- `go test ./...` ✅ (7 tests in cloudinit package)
- `make act` ✅ (all 3 CI jobs pass locally)