### PR TITLE
fix(ci): add govulncheck wrapper and upgrade to Go 1.25

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,4 +17,10 @@ go build ./...
 echo "→ Testing (short)..."
 go test -short ./...
 
+# Vulnerability scan (if govulncheck available)
+if command -v govulncheck >/dev/null 2>&1; then
+  echo "→ Vulnerability scan..."
+  ./scripts/govulncheck.sh
+fi
+
 echo "✓ All pre-push checks passed"

--- a/.govulncheckignore
+++ b/.govulncheckignore
@@ -1,0 +1,9 @@
+# Known upstream vulnerabilities with no available fix.
+# Each line is a Go vulnerability ID (GO-YYYY-NNNN).
+# Checked by scripts/govulncheck.sh — suppressed IDs are
+# reported but do not fail the build.
+
+# Incus local privilege escalation via custom storage volumes
+# https://pkg.go.dev/vuln/GO-2025-4115
+# CVE-2025-0540 — upstream: github.com/lxc/incus — no fix released
+GO-2025-4115

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,9 @@ coverage:
 	$(GO) tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
-# Vulnerability scan (govulncheck)
+# Vulnerability scan (govulncheck with suppression list)
 vuln:
-	@command -v govulncheck >/dev/null 2>&1 || { echo "Install: go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
-	govulncheck ./...
+	@./scripts/govulncheck.sh
 
 # Clean build artifacts
 clean:

--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Wrapper around govulncheck that suppresses known upstream vulnerabilities.
+# Reads suppressed IDs from .govulncheckignore at the repo root.
+# Runs a single JSON scan, filters suppressed IDs, and prints results.
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+IGNORE_FILE="$REPO_ROOT/.govulncheckignore"
+
+command -v govulncheck >/dev/null 2>&1 || {
+    echo "govulncheck not found; installing..."
+    go install golang.org/x/vuln/cmd/govulncheck@latest
+}
+
+# Ensure govulncheck supports the current Go version. If it doesn't,
+# it exits with a version mismatch error — upgrade and retry.
+if ! govulncheck -version >/dev/null 2>&1; then
+    echo "govulncheck does not support current Go version; upgrading..."
+    go install golang.org/x/vuln/cmd/govulncheck@latest
+fi
+
+if [ ! -f "$IGNORE_FILE" ]; then
+    echo "No .govulncheckignore found; running govulncheck without suppressions."
+    exec govulncheck ./...
+fi
+
+# Load suppressed IDs (strip comments and blanks).
+suppress=$(grep -v '^#' "$IGNORE_FILE" | grep -v '^$' | awk '{print $1}')
+
+# Single JSON run — captures structured output for filtering.
+json=$(govulncheck -json ./... 2>&1) || true
+
+# Extract vulnerability IDs from finding objects.
+found_ids=$(printf '%s\n' "$json" \
+    | grep -o '"osv":"GO-[0-9]*-[0-9]*"' \
+    | sed 's/"osv":"//;s/"//' \
+    | sort -u)
+
+if [ -z "$found_ids" ]; then
+    echo "No vulnerabilities found."
+    exit 0
+fi
+
+# Check each found ID against the suppress list.
+unsuppressed=""
+for id in $found_ids; do
+    if echo "$suppress" | grep -qw "$id"; then
+        echo "SUPPRESSED: $id"
+    else
+        unsuppressed="$unsuppressed $id"
+    fi
+done
+
+if [ -n "$unsuppressed" ]; then
+    echo ""
+    echo "FAIL: unsuppressed vulnerabilities found:$unsuppressed"
+    exit 1
+fi
+
+echo "All reported vulnerabilities are suppressed (known upstream issues)."
+exit 0


### PR DESCRIPTION
Fixes CI failure caused by missing govulncheck wrapper script.

- Add scripts/govulncheck.sh wrapper with .govulncheckignore suppression
- Add .govulncheckignore with GO-2025-4115 (Incus, no upstream fix)
- Upgrade to Go 1.25, pin security scan to Go 1.24 for govulncheck compat
- Update Makefile vuln target to use wrapper
- Add vuln scan to pre-push hook